### PR TITLE
Add a basic yaml config file for redis urls using the Vegas CLI.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qless-sharded_ui (0.1)
+    qless-sharded_ui (0.2)
       qless (~> 0.9)
       vegas (~> 0.1)
 
@@ -10,21 +10,21 @@ GEM
   specs:
     columnize (0.3.6)
     daemons (1.1.9)
-    debugger (1.6.0)
+    debugger (1.6.3)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.1)
+      debugger-ruby_core_source (~> 1.2.4)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.2)
+    debugger-ruby_core_source (1.2.4)
     eventmachine (1.0.3)
     qless (0.9.3)
       redis (>= 2.2)
       sinatra (~> 1.3.2)
       vegas (~> 0.1.11)
     rack (1.5.2)
-    rack-protection (1.5.0)
+    rack-protection (1.5.1)
       rack
-    redis (3.0.4)
+    redis (3.0.6)
     sinatra (1.3.6)
       rack (~> 1.4)
       rack-protection (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ qless-sharded-ui
 For large shared Qless installations, qless-sharded-ui provides a way to
 view all your Qless shards on one UI.
 
+It is driven by a simple yaml file, where you list the redis urls:
+
+```
+$ qless-sharded-web --init qless-sharded-web.yml
+$ # Edit qless-sharded-web.yml to taste
+$ qless-sharded-web --config qless-sharded-web.yml
+```

--- a/exe/qless-sharded-web
+++ b/exe/qless-sharded-web
@@ -8,22 +8,49 @@ rescue LoadError
   require 'vegas'
 end
 
+require 'yaml'
 require 'qless/sharded_ui'
-server = Qless::ShardedUI.new([
-  Qless::ShardedClient.new(
-    'foo-0', Qless::Client.new(:url => 'redis://localhost:6379/0'), 'foo-0/'),
-  Qless::ShardedClient.new(
-    'foo-1', Qless::Client.new(:url => 'redis://localhost:6380/0'), 'foo-1/')
-])
 
-Vegas::Runner.new(server, 'qless-sharded-web', {
-  :before_run => lambda {|v|
-    path = (ENV['RESQUECONFIG'] || v.args.first)
-    load path.to_s.strip if path
-  }
-}) do |runner, opts, app|
-  # opts.on('-r redis-connection', "--redis redis-connection", "set the Redis connection string") {|redis_conf|
-  #   runner.logger.info "Using Redis connection '#{redis_conf}'"
-  #   Resque.redis = redis_conf
-  # }
+class LazyShardedUI
+  def call(env)
+    app.call(env)
+  end
+
+  def sharded_clients
+    @sharded_clients ||= []
+  end
+
+  def app
+    @app ||= Qless::ShardedUI.new(sharded_clients)
+  end
+end
+
+Vegas::Runner.new(LazyShardedUI.new, 'qless-sharded-web') do |runner, opts, app|
+  opts.on('--init file', 'create a config file for use with -c')  do |filename|
+    runner.logger.info "Writing to '#{filename}'"
+    File.open(filename, 'w') do |file|
+      file << <<'YAML'
+# Each entry becomes a Qless::ShardedClient, as so:
+# Qless::ShardedClient.new(NAME, Qless::Client.new(:url => URL), PATH)
+
+redis_instances:
+  - name: localhost
+    path: /
+    url: redis://localhost:6379/0
+YAML
+    end
+
+    exit 0
+  end
+
+  opts.on('-c file', '--config file', 'take redis urls from the file')  do |filename|
+    YAML.load_file(filename).fetch('redis_instances').each do |instance_hash|
+      name = instance_hash.fetch('name')
+      path = instance_hash.fetch('path')
+      url = instance_hash.fetch('url')
+
+      client = Qless::ShardedClient.new(name, Qless::Client.new(:url => url), path)
+      app.sharded_clients << client
+    end
+  end
 end

--- a/qless-sharded_ui.gemspec
+++ b/qless-sharded_ui.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "qless-sharded_ui"
-  s.version     = 0.1
+  s.version     = 0.2
   s.authors     = ["Dan Lecocq"]
   s.email       = ["dan@seomoz.org"]
   s.homepage    = "http://github.com/seomoz/qless-sharded-ui"
@@ -22,4 +22,3 @@ Gem::Specification.new do |s|
   s.add_dependency "qless"  , "~> 0.9"
   s.add_dependency "vegas"  , "~> 0.1"
 end
-


### PR DESCRIPTION
The only catch is a chicken-and-egg with option parsing and app construction.  We get around it with a shim app that accumulates constructor arguments and lazily constructs the `Qless::ShardedUI` instance.

The locked version of ruby-debug was also bumped allow it to work with ruby 1.9.3.

I've also dropped a `before_run` hook that `load`ed the value of `RESQUECONFIG` or the first positional argument if either was present. Kick me and I'll make it come back.
